### PR TITLE
disable preview video when tab is not focused

### DIFF
--- a/client/camera-preview.js
+++ b/client/camera-preview.js
@@ -19,6 +19,14 @@ class CameraPreview {
       }
     })
 
+    document.addEventListener('visibilitychange', evt => {
+      if (document.hidden) {
+        return this.stop()
+      }
+
+      return this.initializeCamera()
+    })
+
     let resizeTimeout = null
     window.addEventListener('resize', evt => {
       if (resizeTimeout) {
@@ -108,6 +116,13 @@ class CameraPreview {
     this.videoElem.style.top = `${top}px`
     this.videoElem.style.width = `${width}px`
     this.videoElem.style.height = `${height}px`
+  }
+
+  stop() {
+    if (!this.videoStream) return
+
+    this.videoStream.stop()
+    this.videoStream = null
   }
 
   updateSwitchButton() {


### PR DESCRIPTION
in the interests of preserving battery life and reducing green light eye strain when on a different tab

it works on chrome and firefox 